### PR TITLE
keyboard handler

### DIFF
--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@jdesignlab/flex": "workspace:*",
     "@jdesignlab/react-icons": "workspace:*",
+    "@jdesignlab/react-utils": "workspace:*",
     "@jdesignlab/theme": "workspace:*"
   },
   "devDependencies": {


### PR DESCRIPTION
브랜치를 안따고 push해서 그냥 머지가 되어버렸습니다ㅜㅜ

1. 키보드 핸들러 구현 : 415bcabb90303fa82f0257a33d3ff55520d394ee 
2. 컴포넌트에서 적용 : d07a27c44dd73e1b3d8362c037647e60c9e4e445 (우선 Checkbox, Dropdown에만 적용)

```export const useKeyboardHandler = ({
  event,
  parentScope,
  selectorOfList,
  setState
}: {
  event: React.KeyboardEvent<HTMLElement>;
  parentScope?: string;
  selectorOfList?: string;
  setState?: Dispatch<SetStateAction<boolean>>;
}) => {
  switch (event.key) {
    case 'Space':
    case ' ':
      setState && spaceKeyHandler(setState);
      break;
    case 'ArrowUp':
    case 'ArrowRight':
      parentScope &&
        selectorOfList &&
        arrowKeyHandler({
          event,
          parentScope,
          selectorOfList,
          direction: 'next'
        });
      break;
    case 'ArrowDown':
    case 'ArrowLeft':
      parentScope &&
        selectorOfList &&
        arrowKeyHandler({
          event,
          parentScope,
          selectorOfList,
          direction: 'prev'
        });
      break;
    default:
      break;
  }
};

import type { Dispatch, SetStateAction } from 'react';

export const spaceKeyHandler = (setState: Dispatch<SetStateAction<boolean>>) => {
  setState((prev: boolean) => !prev);
};
```

위처럼 컴포넌트 훅 단계에서 switch를 통해 핸들링을 해줄까, 아예 구현부분을 react-utils에 다 위임해버릴까 고민하다가 모든 구현부분은 react-utils에서 하도록 처리했습니다.

그리고 또 고민됐던 부분은 리스트 이동할 범위와 `tabIndex`를 받아올 노드를 특정할때, ref를 통해 받아올지, 선택자로 받아올지 고민이 됐는데,
부모는 `ref`를 통해 받아온다고 해도 노드리스트는 선택자가 불가피할 것 같아서 결국 선택자를 활용하는 방식으로 채택했습니다. 

최대한 기능구현에 className사용은 지양하려고 했지만 `Dropdown`의 경우 메인아이템과 서브아이템의 차이가 className 밖에  없어서`Dropdown`은 className으로 노드를 가져오는 방향으로 구현했습니다. 