### PR TITLE
Feature/use outside click

### DIFF
--- a/packages/box/CHANGELOG.md
+++ b/packages/box/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @jdesignlab/box
 
+## 0.8.2
+
+### Patch Changes
+
+- @jdesignlab/button@0.12.1
+- @jdesignlab/j-provider@0.7.1
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/box",
   "packageManager": "yarn@3.3.1",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/button/CHANGELOG.md
+++ b/packages/button/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @jdesignlab/button
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/j-provider@0.7.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdesignlab/button",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "packageManager": "yarn@3.3.1",
   "main": "src/index.ts",
   "files": [

--- a/packages/card/CHANGELOG.md
+++ b/packages/card/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @jdesignlab/card
 
+## 0.11.1
+
+### Patch Changes
+
+- @jdesignlab/flex@0.9.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/card",
   "packageManager": "yarn@3.3.1",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/checkbox/CHANGELOG.md
+++ b/packages/checkbox/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @jdesignlab/checkbox
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/j-provider@0.7.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdesignlab/checkbox",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "packageManager": "yarn@3.3.1",
   "files": [

--- a/packages/drawer/CHANGELOG.md
+++ b/packages/drawer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @jdesignlab/drawer
 
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/button@0.12.1
+  - @jdesignlab/flex@0.9.1
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/drawer",
   "packageManager": "yarn@3.3.1",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/dropdown/CHANGELOG.md
+++ b/packages/dropdown/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @jdesignlab/dropdown
 
+## 0.11.0
+
+### Minor Changes
+
+- Add useOutsideClick hook for external clicks
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/flex@0.9.1
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdesignlab/dropdown",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "src/index.ts",
   "packageManager": "yarn@3.3.1",
   "files": [

--- a/packages/dropdown/src/components/Dropdown.tsx
+++ b/packages/dropdown/src/components/Dropdown.tsx
@@ -10,13 +10,15 @@ import { MenuItem } from './DropdownMenuItem';
 import { SubMenu } from './DropdownSubMenu';
 import { SubMenuItem } from './DropdownSubMenuItem';
 import { DropdownContext } from '../context';
+import { useOutsideClick } from '@jdesignlab/react-utils';
+import { useToggleOpen } from '../hooks/useToggleOpen';
 
 export const Dropdown = (props: DropdownProps) => {
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [triggerWidth, setTriggerWidth] = useState<number>(0);
   const [triggerHeight, setTriggerHeight] = useState<number>(0);
   const { children, width = 200, placement = 'buttom', ...otherProps } = props;
   const gap = Number(props.gap) || 0;
-
   const providerValue = {
     placement,
     width,
@@ -26,10 +28,20 @@ export const Dropdown = (props: DropdownProps) => {
     setTriggerHeight,
     gap
   };
-
+  useOutsideClick({
+    ref: dropdownRef,
+    handler: () => {
+      const dropdownMenu = dropdownRef.current
+        ? (dropdownRef.current.querySelector("[role='menu']") as HTMLElement)
+        : null;
+      if (dropdownMenu) {
+        useToggleOpen(dropdownMenu);
+      }
+    }
+  });
   return (
     <DropdownContext.Provider value={providerValue}>
-      <div css={dropdownWrapperStyle} {...otherProps} className="menu_wrapper">
+      <div ref={dropdownRef} css={dropdownWrapperStyle} {...otherProps} className="menu_wrapper">
         {children}
       </div>
     </DropdownContext.Provider>

--- a/packages/dropdown/src/components/DropdownTrigger.tsx
+++ b/packages/dropdown/src/components/DropdownTrigger.tsx
@@ -2,12 +2,12 @@ import { useEffect, useContext, useRef } from 'react';
 import { DropdownContext } from '../context';
 import type { DropdownTriggerProps } from '../types';
 import useOpenKeyDown from '../hooks/useOpenKeyDown';
-import useToggleOpen from '../hooks/useToggleOpen';
+import { useToggleOpen } from '../hooks/useToggleOpen';
 
 export const Trigger = (props: DropdownTriggerProps) => {
   const { children, ...otherProps } = props;
   const { setTriggerWidth, setTriggerHeight } = useContext(DropdownContext);
-  const triggerRef = useRef(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (triggerRef.current) {
@@ -19,8 +19,8 @@ export const Trigger = (props: DropdownTriggerProps) => {
 
   const onClickHandle = () => {
     if (triggerRef?.current) {
-      const el = triggerRef.current as HTMLElement;
-      useToggleOpen(el);
+      const dropdownMenu = triggerRef.current.closest('.menu_wrapper')?.querySelector('[role="menu"]') as HTMLElement;
+      useToggleOpen(dropdownMenu);
     }
   };
 

--- a/packages/dropdown/src/hooks/useToggleOpen.ts
+++ b/packages/dropdown/src/hooks/useToggleOpen.ts
@@ -1,8 +1,6 @@
-const useToggleOpen = (el: HTMLElement) => {
-  const menu = el?.closest('.menu_wrapper')?.querySelector('[role="menu"]');
-  if (menu) {
-    menu.classList.toggle('menu_close');
-    menu.classList.toggle('menu_open');
+export const useToggleOpen = (dropdownMenu: HTMLElement) => {
+  if (dropdownMenu) {
+    dropdownMenu.classList.toggle('menu_close');
+    dropdownMenu.classList.toggle('menu_open');
   }
 };
-export default useToggleOpen;

--- a/packages/flex/CHANGELOG.md
+++ b/packages/flex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @jdesignlab/flex
 
+## 0.9.1
+
+### Patch Changes
+
+- @jdesignlab/j-provider@0.7.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdesignlab/flex",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "packageManager": "yarn@3.3.1",
   "main": "src/index.ts",
   "files": [

--- a/packages/input/CHANGELOG.md
+++ b/packages/input/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @jdesignlab/input
 
+## 0.9.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/j-provider@0.7.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/input",
   "packageManager": "yarn@3.3.1",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/j-provider/CHANGELOG.md
+++ b/packages/j-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @jdesignlab/j-provider
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/j-provider/package.json
+++ b/packages/j-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/j-provider",
   "packageManager": "yarn@3.3.1",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [

--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @jdesignlab/modal
 
+## 0.9.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/button@0.12.1
+  - @jdesignlab/input@0.9.1
+  - @jdesignlab/flex@0.9.1
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/modal",
   "packageManager": "yarn@3.3.1",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @jdesignlab/popover
 
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/button@0.12.1
+  - @jdesignlab/flex@0.9.1
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/popover",
   "packageManager": "yarn@3.3.1",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "src/index.ts",
   "scripts": {
     "test": "jest",

--- a/packages/radio/CHANGELOG.md
+++ b/packages/radio/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @jdesignlab/radio
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/j-provider@0.7.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/radio",
   "packageManager": "yarn@3.3.1",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/react-utils/CHANGELOG.md
+++ b/packages/react-utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @jdesignlab/react-utils
 
+## 0.9.0
+
+### Minor Changes
+
+- Add useOutsideClick hook for external clicks
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/react-utils",
   "packageManager": "yarn@3.3.1",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [

--- a/packages/react-utils/src/hooks/useOutsideClick.ts
+++ b/packages/react-utils/src/hooks/useOutsideClick.ts
@@ -1,0 +1,22 @@
+import { RefObject, useEffect } from 'react';
+
+type Props = {
+  ref: RefObject<HTMLElement>;
+  handler: (event: MouseEvent) => void;
+};
+
+export const useOutsideClick = ({ ref, handler }: Props) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+    };
+  });
+};

--- a/packages/react-utils/src/index.ts
+++ b/packages/react-utils/src/index.ts
@@ -16,3 +16,4 @@ export * from './mixins/styles/usePlacementStyle';
 
 /** hooks */
 export * from './hooks/useInitialRender';
+export * from './hooks/useOutsideClick';

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @jdesignlab/react
 
+## 0.11.0
+
+### Minor Changes
+
+- remove unused export files
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/dropdown@0.11.0
+  - @jdesignlab/select@0.10.0
+  - @jdesignlab/button@0.12.1
+  - @jdesignlab/checkbox@0.8.1
+  - @jdesignlab/drawer@0.8.2
+  - @jdesignlab/input@0.9.1
+  - @jdesignlab/j-provider@0.7.1
+  - @jdesignlab/modal@0.9.2
+  - @jdesignlab/popover@0.8.2
+  - @jdesignlab/radio@0.8.1
+  - @jdesignlab/stack@0.7.1
+  - @jdesignlab/typography@0.8.1
+  - @jdesignlab/textarea@0.11.2
+  - @jdesignlab/tooltip@0.7.2
+  - @jdesignlab/box@0.8.2
+  - @jdesignlab/flex@0.9.1
+  - @jdesignlab/card@0.11.1
+
 ## 0.10.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/react",
   "packageManager": "yarn@3.3.1",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist"
   ],
+  "license": "MIT",
   "contributors": [
     {
       "name": "jiny",
@@ -20,6 +21,15 @@
       "email": "jy7828@gmail.com",
       "url": "https://github.com/yoycode"
     }
+  ],
+  "keywords": [
+    "components",
+    "design-system",
+    "emotion",
+    "library",
+    "react",
+    "react-components",
+    "ui"
   ],
   "scripts": {
     "test": "jest",

--- a/packages/react/src/hooks/useOutsideClick.ts
+++ b/packages/react/src/hooks/useOutsideClick.ts
@@ -1,0 +1,22 @@
+import { RefObject, useEffect } from 'react';
+
+type Props = {
+  ref: RefObject<HTMLElement>;
+  handler: (event: MouseEvent) => void;
+};
+
+export const useOutsideClick = ({ ref, handler }: Props) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+    };
+  });
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,7 +10,6 @@ export * from '@jdesignlab/j-provider';
 export * from '@jdesignlab/modal';
 export * from '@jdesignlab/popover';
 export * from '@jdesignlab/radio';
-// export * from '@jdesignlab/react-icons';
 export * from '@jdesignlab/react-utils';
 export * from '@jdesignlab/select';
 export * from '@jdesignlab/stack';

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @jdesignlab/select
 
+## 0.10.0
+
+### Minor Changes
+
+- Add useOutsideClick hook for external clicks
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/button@0.12.1
+  - @jdesignlab/flex@0.9.1
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/select",
   "packageManager": "yarn@3.3.1",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/select/src/components/SelectContainer.tsx
+++ b/packages/select/src/components/SelectContainer.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useContext, useEffect, useRef, useState, useId } from 'react';
-import { SELECT_ID_PREPIX } from '../constants';
+import { useOutsideClick } from '@jdesignlab/react-utils';
+import { SELECT_ID_PREFIX } from '../constants';
 import { SelectContext } from '../hooks/SelectContext';
 import { createSelectStyle } from '../styles/createSelectStyle';
 import { ComboboxOption } from './ComboboxOption';
@@ -8,14 +9,22 @@ import { SelectNotfound } from './SearchNotfound';
 import { ContainerProps } from '../types';
 
 export const SelectContainer = (props: ContainerProps) => {
-  const { selectProps, open, setSelectRef, searchValues, searchKeyword } = useContext(SelectContext);
+  const { selectProps, open, setSelectRef, searchValues, searchKeyword, setOpen } = useContext(SelectContext);
   const { Trigger, Options } = props;
   const { listStyle, active, wrapperStyle } = createSelectStyle(selectProps);
   const [input, setInput] = useState<HTMLInputElement | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const ulRef = useRef<HTMLUListElement>(null);
   const uid = useId();
-  const selectElementId = `${SELECT_ID_PREPIX}-${uid}`;
+  const selectElementId = `${SELECT_ID_PREFIX}-${uid}`;
+
+  useOutsideClick({
+    ref: containerRef,
+    handler: function () {
+      setOpen(false);
+    }
+  });
+
   useEffect(() => {
     if (containerRef.current) {
       setSelectRef(containerRef);

--- a/packages/select/src/constants.ts
+++ b/packages/select/src/constants.ts
@@ -1,10 +1,10 @@
 import { ColorToken } from '@jdesignlab/theme';
 
-const SELECT_ID_PREPIX: string = 'jdesignlab-select-list';
+const SELECT_ID_PREFIX: string = 'jdesignlab-select-list';
 const FONT_COLOR: ColorToken = 'font';
 const BORDER_COLOR: ColorToken = 'border';
 const DISABLED_COLOR: ColorToken = 'disabled';
 const FOCUS_COLOR: ColorToken = 'primary-500';
 const BORDER_RADIUS: number = 4;
 
-export { FONT_COLOR, BORDER_COLOR, BORDER_RADIUS, DISABLED_COLOR, FOCUS_COLOR, SELECT_ID_PREPIX };
+export { FONT_COLOR, BORDER_COLOR, BORDER_RADIUS, DISABLED_COLOR, FOCUS_COLOR, SELECT_ID_PREFIX };

--- a/packages/stack/CHANGELOG.md
+++ b/packages/stack/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @jdesignlab/stack
 
+## 0.7.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/stack",
   "packageManager": "yarn@3.3.1",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "src/index.ts",
   "files": [
     "dist"

--- a/packages/text/CHANGELOG.md
+++ b/packages/text/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @jdesignlab/typography
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/j-provider@0.7.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/typography",
   "packageManager": "yarn@3.3.1",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [

--- a/packages/textarea/CHANGELOG.md
+++ b/packages/textarea/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @jdesignlab/textarea
 
+## 0.11.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/typography@0.8.1
+
 ## 0.11.1
 
 ### Patch Changes

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jdesignlab/textarea",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "packageManager": "yarn@3.3.1",
   "main": "src/index.ts",
   "files": [

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @jdesignlab/tooltip
 
+## 0.7.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @jdesignlab/react-utils@0.9.0
+  - @jdesignlab/button@0.12.1
+  - @jdesignlab/j-provider@0.7.1
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jdesignlab/tooltip",
   "packageManager": "yarn@3.3.1",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "src/index.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Select, Dropdown에 적용 할 `useOutsideClick` 커스텀 훅을 개발하였습니다.

### Interface
```tsx
//src/react-utils/hooks/useOutsideClick
import { RefObject, useEffect } from 'react';

type Props = {
  ref: RefObject<HTMLElement>;
  handler: (event: MouseEvent) => void;
};

export const useOutsideClick = ({ ref, handler }: Props) => {
  useEffect(() => {
    const listener = (event: MouseEvent) => {
      if (!ref.current || ref.current.contains(event.target as Node)) {
        return;
      }
      handler(event);
    };

    document.addEventListener('mousedown', listener);
    return () => {
      document.removeEventListener('mousedown', listener);
    };
  });
};

```

```tsx
import { useOutsideClick } from '@jdesignlab/react-utils';

export const SelectContainer = (props: ContainerProps) => {
  ...

  useOutsideClick({
    ref: containerRef, //참조할 HTML Element
    handler: function () { //'mouseover' 이벤트 핸들러
      setOpen(false);
    }
  });



  return (
    <div
      css={wrapperStyle}
      ref={containerRef}
      role={input ? 'combobox' : 'listbox'}
      aria-controls={selectElementId}
      aria-label={selectProps.placeholder || 'Select List'}
      aria-expanded={open}
      aria-haspopup={true}
      aria-disabled={selectProps.disabled}
    >
    //Component Code
    </div>
  );
};
```

### Issue
**[chakar-ui/useOutsideClick](https://chakra-ui.com/docs/hooks/use-outside-click)**
#79 